### PR TITLE
Basic plugin that removes the thumbs up/thumbs down from the left sidebar, as well as the amount of each that is shown when you click on a candidate.

### DIFF
--- a/main.js
+++ b/main.js
@@ -1,0 +1,22 @@
+var thumbsUps = document.getElementsByClassName("icon-thumb-up");
+var thumbsDowns = document.getElementsByClassName("icon-thumb-down");
+var widgets = document.getElementsByClassName("rating-widget__item");
+var toHide = [thumbsUps, thumbsDowns, widgets];
+
+for (var i in toHide) {
+    var currentList = toHide[i];
+
+    for (var j in currentList) {
+        try {
+            currentList[j].style.display = 'none';
+        } catch (e) {
+            console.log(currentList[j]);
+            if (!currentList[j].style) {
+                currentList[j].style = { display: 'none' };
+            } else {
+                console.log(e);
+            }
+        }
+    }
+}
+

--- a/manifest.json
+++ b/manifest.json
@@ -6,7 +6,14 @@
   "page_action": {
     "default_title": "Hide ratings"
   },
-  "permissions": {
-    "storage"
-  }
+  "content_scripts": [
+    {
+      "matches": [
+        "https://*.workable.com/backend/jobs/*"
+      ],
+      "js": [
+        "main.js"
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
 - Add basic script to remove ratings widgets from the DOM. Edit manifest to point to that script and to only have the script affect pages from workable.

